### PR TITLE
Widget id validation issue 8

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*.*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+.DS_Store
 node_modules/
+.idea/
+.atom/

--- a/app/index.js
+++ b/app/index.js
@@ -74,9 +74,9 @@ module.exports = generators.Base.extend({
         default: this.user.git.email
       }
     ], (answers) => {
-      props       = answers;
+      props = answers;
       props.build = answers.proj_type !== 'basic';
-      props.main  = answers.build ? 'dist/app.js' : 'app.js';
+      props.main = answers.build ? 'dist/app.js' : 'app.js';
       done();
     });
   },

--- a/app/index.js
+++ b/app/index.js
@@ -15,7 +15,7 @@ var projectTypes = [{
 var props;
 
 module.exports = generators.Base.extend({
-  prompting: function() {
+  prompting: function () {
     var done = this.async();
     this.prompt([
       {
@@ -44,7 +44,10 @@ module.exports = generators.Base.extend({
         type: 'input',
         name: 'app_id',
         message: 'App ID',
-        default: answers => answers.name
+        validate: (input) => {
+          return (/\-|\s/.test(input)) ? 'Invalid App ID, use alphanumeric and periods only' : true;
+        },
+        default: answers => toAppId(answers.name)
       }, {
         when: answers => answers.prep_build,
         type: 'input',
@@ -71,14 +74,14 @@ module.exports = generators.Base.extend({
         default: this.user.git.email
       }
     ], (answers) => {
-      props = answers;
+      props       = answers;
       props.build = answers.proj_type !== 'basic';
-      props.main = answers.build ? 'dist/app.js' : 'app.js';
+      props.main  = answers.build ? 'dist/app.js' : 'app.js';
       done();
     });
   },
 
-  writing: function() {
+  writing: function () {
     this.fs.copyTpl(
       this.templatePath('_package.json'),
       this.destinationPath('package.json'),
@@ -132,7 +135,7 @@ module.exports = generators.Base.extend({
     }
   },
 
-  install: function() {
+  install: function () {
     this.npmInstall(['tabris'], {
       save: true
     });
@@ -163,6 +166,10 @@ module.exports = generators.Base.extend({
 
 function toId(string) {
   return string.replace(/\s+/g, '-').toLowerCase();
+}
+
+function toAppId(string) {
+  return string.replace(/\s+/g, '.').replace(/\-+/g, '.').toLowerCase();
 }
 
 function toName(str) {

--- a/app/index.js
+++ b/app/index.js
@@ -15,7 +15,7 @@ var projectTypes = [{
 var props;
 
 module.exports = generators.Base.extend({
-  prompting: function () {
+  prompting: function() {
     var done = this.async();
     this.prompt([
       {
@@ -81,7 +81,7 @@ module.exports = generators.Base.extend({
     });
   },
 
-  writing: function () {
+  writing: function() {
     this.fs.copyTpl(
       this.templatePath('_package.json'),
       this.destinationPath('package.json'),
@@ -135,7 +135,7 @@ module.exports = generators.Base.extend({
     }
   },
 
-  install: function () {
+  install: function() {
     this.npmInstall(['tabris'], {
       save: true
     });


### PR DESCRIPTION
Some minor project updates (editorconfig and gitignore), but mostly to satisfy #8 

The Validation rules for app ID are not exhaustive, but should be more helpful to save some errors when people attempt to build their project and discover that app ID's such as `hello-world` are not valid.

The string comparison should still allow for `*.hello.world` if your Apple App ID is a 'wild card' yee haa! 