### PR TITLE
Validate App ID

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -44,7 +44,10 @@ module.exports = generators.Base.extend({
         type: 'input',
         name: 'app_id',
         message: 'App ID',
-        default: answers => answers.name
+        validate: (input) => {
+          return (/\-|\s/.test(input)) ? 'Invalid App ID, use alphanumeric and periods only' : true;
+        },
+        default: answers => toAppId(answers.name)
       }, {
         when: answers => answers.prep_build,
         type: 'input',
@@ -163,6 +166,10 @@ module.exports = generators.Base.extend({
 
 function toId(string) {
   return string.replace(/\s+/g, '-').toLowerCase();
+}
+
+function toAppId(string) {
+  return string.replace(/\s+/g, '.').replace(/\-+/g, '.').toLowerCase();
 }
 
 function toName(str) {


### PR DESCRIPTION
Some users including myself have generated incorrect output
by using an invalid App ID

- Updated to offer a sensible default for App ID

if the default App ID is not accepted by the user

- Updated to validate user input for App ID

Note: It is not perfectly clear what constitutes valid.
However,  this commit at least means that a
default App ID will be valid

Resolves: #8