### PR TITLE
Set up test automation for Travis CI server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "6"
+  - "5"
+  - "4"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Tabris.js generator
 
+[![Build Status](https://travis-ci.org/eclipsesource/generator-tabris-js.svg?branch=master)](https://travis-ci.org/eclipsesource/generator-tabris-js)
+
 A [Yeoman](http://yeoman.io) generator for [Tabris.js](https://tabrisjs.com/) apps. It lets you quickly set up a new project with sensible defaults and best practices.
 
 ## Getting Started

--- a/app/utilities.js
+++ b/app/utilities.js
@@ -15,7 +15,7 @@ module.exports = {
       .join(' ');
   },
   appIdIsValid(string) {
-    let validAppIdRegex = RegExp(/^([a-z0-9_]+\.)*[a-z][a-z0-9_]+$/, 'i');
+    let validAppIdRegex = RegExp(/^([a-z0-9_]+\.)*[a-z][a-z0-9_]+$/i);
     return validAppIdRegex.test(string);
   }
 };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "engine-strict": true,
   "scripts": {
     "lint": "eslint .",
-    "test": "eslint . && mocha --compilers js:babel-core/register"
+    "test": "eslint . && mocha --compilers js:babel-core/register",
+    "test-watch": "eslint . && mocha --watch --growl --compilers js:babel-core/register"
   }
 }


### PR DESCRIPTION
Since the recent addition of a mocha based test suite,
a CI server is now appropriate.

- Added `.travis.yml` and build status badge to the README
- Updated regex code syntax to pass linting
- Added a script command to `package.json` for running a watch on tests

While developing, please run `npm run test-watch`
for continuous test suite execution when files are changed

Resolves: #24