### PR TITLE
Use semver to validate version number

### DIFF
--- a/app/generator.js
+++ b/app/generator.js
@@ -1,5 +1,6 @@
 const Generator = require('yeoman-generator');
 const {toId, toAppId, toName, isValidAppId} = require('./utilities.js');
+const semver = require('semver');
 
 const PROJECT_TYPES = [{
   name: '1 - JavaScript App',
@@ -31,7 +32,9 @@ module.exports = class extends Generator {
         type: 'input',
         name: 'version',
         message: 'Initial version',
-        default: '0.1.0'
+        default: '0.1.0',
+        validate: input => semver.valid(input) ||
+          'Invalid version number, use valid semver (major.minor.patch)'
       }, {
         type: 'list',
         name: 'proj_type',

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "app"
   ],
   "dependencies": {
+    "semver": "^5.3.0",
     "yeoman-generator": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
As mentioned in https://github.com/eclipsesource/tabris-js/issues/1402 the generator allows users to create a `package.json` that does not conform to the semantic versioning spec.  This PR adds `semver` as a dependency and uses its `valid` method to validate the user's input.  If the user does not enter a valid version number, they will receive feedback.

---

Adding `semver` as a dependency shouldn't affect the package's installation time, as there's already a dependency on this same version of `semver`:
```plain
generator-tabris-js@2.0.0-rc2
└─┬ tslint@4.5.1
  └─┬ update-notifier@2.2.0
    └─┬ semver-diff@2.1.0
      └── semver@5.3.0
```
There are also several other dependencies of `tabris-js-cli` that depend on this version so it will just be de-duped.