### PR TITLE
Setup the TypeScript compiler for JSX apps

### DIFF
--- a/app/generator.js
+++ b/app/generator.js
@@ -64,7 +64,7 @@ module.exports = class extends Generator {
       choices: CONFIG
     }
     ]).then(answers => {
-      const tsc = !answers.template.startsWith('js');
+      const tsc = answers.template !== 'js';
       const tabrisLatest = this._npmVersion('tabris@latest').pop();
       this._props = {
         app_id: answers.app_id,


### PR DESCRIPTION
In the case of the jsx template, the typescript compiler is not correctly configured.
The JSX code needs the typescript compiler, this modification fixes the problem.